### PR TITLE
Link to source

### DIFF
--- a/views/layout.utml
+++ b/views/layout.utml
@@ -44,7 +44,7 @@
       <hr>
 
       <footer>
-        OpenFarmGame is brought to you by <a href="http://e14n.com/">E14N</a>, because we think you&apos;re awesome.
+        <a href="https://github.com/e14n/openfarmgame/">OpenFarmGame</a> is brought to you by <a href="http://e14n.com/">E14N</a>, because we think you&apos;re awesome.
       </footer>
 
     </div> <!-- /container -->


### PR DESCRIPTION
It seems unnecessarily difficult for a user to locate the source code from the website; one might easily come to the incorrect conclusion that the game was nonfree. Linking to the github in the footer should mitigate this somewhat.
